### PR TITLE
feat: Add dark mode support

### DIFF
--- a/src/app/activity/[id]/page.tsx
+++ b/src/app/activity/[id]/page.tsx
@@ -10,7 +10,7 @@ import { motion } from 'framer-motion'
 import { useAtom } from 'jotai'
 import { ArrowLeft, Pause, Play, Square } from 'lucide-react'
 import { useParams, useRouter } from 'next/navigation'
-import { useMemo, useState, useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { ActivityActionBar } from '@/components/activity/ActivityActionBar'
 import { AIInsight } from '@/components/activity/AIInsight'
@@ -58,7 +58,7 @@ export default function ActivityDetailPage() {
   // Parse GPX data and generate track points
   const { paceSegments, kmMarkers, trackPoints, bounds, heartRateData } = useMemo(() => {
     let points: TrackPoint[] = []
-    let hrData: { distance: number; heartRate: number }[] = []
+    const hrData: { distance: number; heartRate: number }[] = []
 
     // Try to parse real GPX data from activity
     if (data?.activity.gpxData) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,34 @@
 import '../styles/globals.css'
 
 import { PageTransitionProvider } from '@/lib/animation'
+import { ThemeProvider } from '@/lib/theme'
 import { TRPCProvider } from '@/lib/trpc/Provider'
 
 export { metadata } from './metadata'
 
+// Script to prevent flash of wrong theme on initial load
+const themeScript = `
+  (function() {
+    const stored = localStorage.getItem('theme');
+    let theme = stored;
+    if (!theme || theme === 'system') {
+      theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    document.documentElement.setAttribute('data-theme', theme);
+  })();
+`
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="zh-CN">
+    <html lang="zh-CN" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+      </head>
       <body>
         <TRPCProvider>
-          <PageTransitionProvider>{children}</PageTransitionProvider>
+          <ThemeProvider>
+            <PageTransitionProvider>{children}</PageTransitionProvider>
+          </ThemeProvider>
         </TRPCProvider>
       </body>
     </html>

--- a/src/components/activity/StatsCard.tsx
+++ b/src/components/activity/StatsCard.tsx
@@ -85,7 +85,8 @@ function Sparkline({
       const midX = (prev.x + curr.x) / 2
       linePath += ` Q ${prev.x} ${prev.y} ${midX} ${(prev.y + curr.y) / 2}`
     }
-    const lastPt = pts[pts.length - 1]
+    const lastPt = pts.at(-1)
+    if (!lastPt) return { path: '', areaPath: '', points: pts }
     linePath += ` L ${lastPt.x} ${lastPt.y}`
 
     // Create area path for gradient fill
@@ -135,10 +136,10 @@ function Sparkline({
       />
 
       {/* End point dot */}
-      {points.length > 0 && (
+      {points.length > 0 && points.at(-1) && (
         <motion.circle
-          cx={points[points.length - 1].x}
-          cy={points[points.length - 1].y}
+          cx={points.at(-1)!.x}
+          cy={points.at(-1)!.y}
           r={2.5}
           fill={color}
           initial={{ scale: 0 }}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,10 +8,12 @@
 
 import { motion } from 'framer-motion'
 
+import { ThemeToggle } from '@/components/ui/ThemeToggle'
+
 export function Header() {
   return (
     <header className="sticky top-0 z-50 w-full">
-      <div className="container mx-auto flex h-16 max-w-6xl items-center px-4 sm:px-6 lg:px-8">
+      <div className="container mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <motion.div
           className="flex items-center gap-3"
           initial={{ opacity: 0, x: -20 }}
@@ -20,6 +22,14 @@ export function Header() {
         >
           <span className="text-xl">🏃</span>
           <h1 className="text-label text-lg font-semibold tracking-tight">RunPaceFlow</h1>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ delay: 0.2, duration: 0.4 }}
+        >
+          <ThemeToggle />
         </motion.div>
       </div>
     </header>

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,61 @@
+/**
+ * ThemeToggle Component
+ *
+ * Button to toggle between light/dark/system themes
+ */
+
+'use client'
+
+import { motion } from 'framer-motion'
+import { Monitor, Moon, Sun } from 'lucide-react'
+
+import type { Theme } from '@/lib/theme'
+import { useTheme } from '@/lib/theme'
+
+const themeIcons = {
+  light: Sun,
+  dark: Moon,
+  system: Monitor,
+}
+
+const themeLabels = {
+  light: '浅色',
+  dark: '深色',
+  system: '跟随系统',
+}
+
+const themeOrder: Theme[] = ['light', 'dark', 'system']
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+
+  const cycleTheme = () => {
+    const currentIndex = themeOrder.indexOf(theme)
+    const nextIndex = (currentIndex + 1) % themeOrder.length
+    setTheme(themeOrder[nextIndex])
+  }
+
+  const Icon = themeIcons[theme]
+
+  return (
+    <motion.button
+      type="button"
+      onClick={cycleTheme}
+      className="flex items-center gap-2 rounded-full border border-white/20 bg-white/50 px-3 py-1.5 text-sm backdrop-blur-xl transition-colors hover:bg-white/70 dark:border-white/10 dark:bg-black/30 dark:hover:bg-black/50"
+      whileHover={{ scale: 1.02 }}
+      whileTap={{ scale: 0.98 }}
+      title={`当前: ${themeLabels[theme]}`}
+    >
+      <motion.div
+        key={theme}
+        initial={{ rotate: -90, opacity: 0 }}
+        animate={{ rotate: 0, opacity: 1 }}
+        exit={{ rotate: 90, opacity: 0 }}
+        transition={{ duration: 0.2 }}
+      >
+        <Icon className="text-label h-4 w-4" />
+      </motion.div>
+      <span className="text-label/70 hidden sm:inline">{themeLabels[theme]}</span>
+    </motion.button>
+  )
+}

--- a/src/lib/theme/ThemeProvider.tsx
+++ b/src/lib/theme/ThemeProvider.tsx
@@ -1,0 +1,95 @@
+/**
+ * ThemeProvider Component
+ *
+ * Manages theme state (light/dark/system) with localStorage persistence
+ * Uses data-theme attribute for CSS variable switching
+ */
+
+'use client'
+
+import { createContext, use, useCallback, useEffect, useState } from 'react'
+
+export type Theme = 'light' | 'dark' | 'system'
+
+interface ThemeContextValue {
+  theme: Theme
+  resolvedTheme: 'light' | 'dark'
+  setTheme: (theme: Theme) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+const STORAGE_KEY = 'theme'
+
+function getSystemTheme(): 'light' | 'dark' {
+  if (typeof window === 'undefined') return 'light'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function getStoredTheme(): Theme {
+  if (typeof window === 'undefined') return 'system'
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored === 'light' || stored === 'dark' || stored === 'system') {
+    return stored
+  }
+  return 'system'
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>('system')
+  const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light')
+  const [mounted, setMounted] = useState(false)
+
+  // Initialize theme from localStorage
+  useEffect(() => {
+    const stored = getStoredTheme()
+    setThemeState(stored)
+    setMounted(true)
+  }, [])
+
+  // Update resolved theme and apply to document
+  useEffect(() => {
+    if (!mounted) return
+
+    const resolved = theme === 'system' ? getSystemTheme() : theme
+    setResolvedTheme(resolved)
+
+    // Apply theme to document
+    document.documentElement.dataset.theme = resolved
+  }, [theme, mounted])
+
+  // Listen for system theme changes
+  useEffect(() => {
+    if (!mounted || theme !== 'system') return
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const handleChange = () => {
+      const resolved = getSystemTheme()
+      setResolvedTheme(resolved)
+      document.documentElement.dataset.theme = resolved
+    }
+
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [theme, mounted])
+
+  const setTheme = useCallback((newTheme: Theme) => {
+    setThemeState(newTheme)
+    localStorage.setItem(STORAGE_KEY, newTheme)
+  }, [])
+
+  // Prevent flash of wrong theme
+  if (!mounted) {
+    return null
+  }
+
+  return <ThemeContext value={{ theme, resolvedTheme, setTheme }}>{children}</ThemeContext>
+}
+
+export function useTheme() {
+  const context = use(ThemeContext)
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}

--- a/src/lib/theme/index.ts
+++ b/src/lib/theme/index.ts
@@ -1,0 +1,1 @@
+export { type Theme, ThemeProvider, useTheme } from './ThemeProvider'


### PR DESCRIPTION
## Summary
- Add ThemeProvider with localStorage persistence for theme state management
- Add ThemeToggle button in header supporting light/dark/system modes
- Use `data-theme` attribute for CSS variable switching with tailwindcss-uikit-colors
- Add inline script to prevent flash of wrong theme on initial load

## Test plan
- [ ] Toggle between light/dark/system modes
- [ ] Verify theme persists after page refresh
- [ ] Verify system mode follows OS preference
- [ ] Check all pages render correctly in both themes

Closes #4

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>